### PR TITLE
feat: add filename casing filters

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig([
         "warn",
         {
           brands: ["Obsidian", "Snipd"],
-          acronyms: ["OK"],
+          acronyms: ["OK", "README", "README.md"],
           enforceCamelCaseLower: true,
         },
       ],

--- a/src/formatting_modal.ts
+++ b/src/formatting_modal.ts
@@ -78,6 +78,11 @@ export class FormattingConfigModal extends Modal {
     fileNameVarsDesc.setText('Variables (click to copy): ');
     const fileNameVars = [
       '{{episode_title}}',
+      '{{episode_title | kebab}}',
+      '{{episode_title | snake}}',
+      '{{episode_title | camel}}',
+      '{{episode_title | pascal}}',
+      '{{episode_title | lowercase}}',
       '{{episode_duration}}',
       '{{episode_publish_date}}',
       '{{episode_url}}'
@@ -98,6 +103,9 @@ export class FormattingConfigModal extends Modal {
         fileNameVarsDesc.appendText(', ');
       }
     });
+
+    const formatTipsDesc = fileNameSection.createDiv({ cls: 'setting-item-description snipd-kebab-tip' });
+    formatTipsDesc.setText('Tip: Use case filters like "| kebab", "| snake", "| camel", "| pascal", or "| lowercase" to format variables (e.g. {{episode_title | snake}}).');
     
     const fileNameInput = fileNameSection.createEl('input', {
       cls: 'snipd-template-input',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1068,6 +1068,10 @@ export default class SnipdPlugin extends Plugin {
         if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
           relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
         }
+        if (relativePath.toLowerCase() === 'readme.md' && !this.settings.syncReadme) {
+          debugLog('Snipd plugin: skipping README.md file - syncReadme setting is disabled.');
+          continue;
+        }
         const baseFilePath = normalizePath(`${folderPath}/${relativePath}`);
         filesInZip.add(baseFilePath);
         
@@ -1217,6 +1221,10 @@ export default class SnipdPlugin extends Plugin {
         }
         if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
           relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
+        }
+        if (relativePath.toLowerCase() === 'readme.md' && !this.settings.syncReadme) {
+          debugLog('Snipd plugin: skipping README.md file - syncReadme setting is disabled.');
+          continue;
         }
         const baseFilePath = normalizePath(`${folderPath}/${relativePath}`);
         

--- a/src/main.ts
+++ b/src/main.ts
@@ -928,7 +928,8 @@ export default class SnipdPlugin extends Plugin {
     totalSnipCount?: number
   ) {
     const subDirPart = this.settings.subDir ? `/${this.settings.subDir}` : '';
-    const targetPath = normalizePath(`${this.settings.snipdDir}${subDirPart}/${showName}/${entityName}.md`);
+    const showFolderPart = this.settings.groupFilesIntoFolders ? `/${showName}` : '';
+    const targetPath = normalizePath(`${this.settings.snipdDir}${subDirPart}${showFolderPart}/${entityName}.md`);
 
     await createDirForFile(targetPath, this.fs);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1066,7 +1066,11 @@ export default class SnipdPlugin extends Plugin {
           relativePath = relativePath.substring(6);
         }
         if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
-          relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
+          const replacement = this.settings.baseSubDir ? `${this.settings.baseSubDir}/` : '';
+          relativePath = relativePath.replace(/^Base\//, replacement);
+        }
+        if (relativePath.endsWith('Snipd.base') && this.settings.baseFileName !== 'Snipd.base') {
+          relativePath = relativePath.replace(/Snipd\.base$/, this.settings.baseFileName);
         }
         if (relativePath.toLowerCase() === 'readme.md' && !this.settings.syncReadme) {
           debugLog('Snipd plugin: skipping README.md file - syncReadme setting is disabled.');
@@ -1220,7 +1224,11 @@ export default class SnipdPlugin extends Plugin {
           relativePath = relativePath.substring(6);
         }
         if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
-          relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
+          const replacement = this.settings.baseSubDir ? `${this.settings.baseSubDir}/` : '';
+          relativePath = relativePath.replace(/^Base\//, replacement);
+        }
+        if (relativePath.endsWith('Snipd.base') && this.settings.baseFileName !== 'Snipd.base') {
+          relativePath = relativePath.replace(/Snipd\.base$/, this.settings.baseFileName);
         }
         if (relativePath.toLowerCase() === 'readme.md' && !this.settings.syncReadme) {
           debugLog('Snipd plugin: skipping README.md file - syncReadme setting is disabled.');
@@ -1293,9 +1301,16 @@ export default class SnipdPlugin extends Plugin {
     }
     
     if (!defaultOpenPath) {
-      defaultOpenPath = `${this.settings.baseSubDir}/Snipd.base`;
-    } else if (defaultOpenPath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
-      defaultOpenPath = defaultOpenPath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
+      const subDirPart = this.settings.baseSubDir ? `${this.settings.baseSubDir}/` : '';
+      defaultOpenPath = `${subDirPart}${this.settings.baseFileName}`;
+    } else {
+      if (defaultOpenPath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
+        const replacement = this.settings.baseSubDir ? `${this.settings.baseSubDir}/` : '';
+        defaultOpenPath = defaultOpenPath.replace(/^Base\//, replacement);
+      }
+      if (defaultOpenPath.endsWith('Snipd.base') && this.settings.baseFileName !== 'Snipd.base') {
+        defaultOpenPath = defaultOpenPath.replace(/Snipd\.base$/, this.settings.baseFileName);
+      }
     }
     
     const baseFilePath = normalizePath(`${this.settings.snipdDir}/${defaultOpenPath}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ function isValidAdditionalProperties(
 ): props is Array<{ name: string; template: string; displayName?: string }> {
   return Array.isArray(props) && props.length > 0 && props.every((p) => !!p.name?.trim() && !!p.template?.trim());
 }
-import { generateEpisodeFileName, createDirForFile, isDev, debugLog } from './utils';
+import { generateEpisodeFileName, createDirForFile, isDev, debugLog, applyCaseFormat } from './utils';
 import { sanitizeFileName } from './sanitize_file_name';
 import { SnipdSettingModal } from './settings_modal';
 import { SecureStorage } from './secure_storage';
@@ -876,7 +876,10 @@ export default class SnipdPlugin extends Plugin {
       }
       const episodeName = generateEpisodeFileName(episodeData, episodeId, this.settings);
       const showId = episodeData?.show_id;
-      const showName = showId && showsData[showId] ? showsData[showId].name : 'Unknown Show';
+      let showName = showId && showsData[showId] ? showsData[showId].name : 'Unknown Show';
+      if (this.settings.folderNameCase && this.settings.folderNameCase !== 'default') {
+        showName = applyCaseFormat(showName, this.settings.folderNameCase);
+      }
 
       await this.syncFile(
         fileData.full,

--- a/src/main.ts
+++ b/src/main.ts
@@ -924,7 +924,8 @@ export default class SnipdPlugin extends Plugin {
     showName: string,
     totalSnipCount?: number
   ) {
-    const targetPath = normalizePath(`${this.settings.snipdDir}/Data/${showName}/${entityName}.md`);
+    const subDirPart = this.settings.subDir ? `/${this.settings.subDir}` : '';
+    const targetPath = normalizePath(`${this.settings.snipdDir}${subDirPart}/${showName}/${entityName}.md`);
 
     await createDirForFile(targetPath, this.fs);
 
@@ -1063,6 +1064,9 @@ export default class SnipdPlugin extends Plugin {
         let relativePath = zipEntry.filename;
         if (relativePath.startsWith('Files/')) {
           relativePath = relativePath.substring(6);
+        }
+        if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
+          relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
         }
         const baseFilePath = normalizePath(`${folderPath}/${relativePath}`);
         filesInZip.add(baseFilePath);
@@ -1211,6 +1215,9 @@ export default class SnipdPlugin extends Plugin {
         if (relativePath.startsWith('Files/')) {
           relativePath = relativePath.substring(6);
         }
+        if (relativePath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
+          relativePath = relativePath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
+        }
         const baseFilePath = normalizePath(`${folderPath}/${relativePath}`);
         
         await createDirForFile(baseFilePath, this.app.vault.adapter);
@@ -1278,7 +1285,9 @@ export default class SnipdPlugin extends Plugin {
     }
     
     if (!defaultOpenPath) {
-      defaultOpenPath = 'Base/Snipd.base';
+      defaultOpenPath = `${this.settings.baseSubDir}/Snipd.base`;
+    } else if (defaultOpenPath.startsWith('Base/') && this.settings.baseSubDir !== 'Base') {
+      defaultOpenPath = defaultOpenPath.replace(/^Base\//, `${this.settings.baseSubDir}/`);
     }
     
     const baseFilePath = normalizePath(`${this.settings.snipdDir}/${defaultOpenPath}`);

--- a/src/settings_modal.ts
+++ b/src/settings_modal.ts
@@ -220,6 +220,26 @@ export class SnipdSettingModal extends PluginSettingTab {
         }));
 
     new Setting(containerEl)
+      .setName('Podcast folder casing')
+      .setDesc('Apply case formatting to podcast folder names.')
+      .addDropdown(dropdown => {
+        dropdown.addOption('default', 'Default');
+        dropdown.addOption('kebab', 'Kebab case');
+        dropdown.addOption('snake', 'Snake case');
+        dropdown.addOption('camel', 'Camel case');
+        dropdown.addOption('pascal', 'Pascal case');
+        dropdown.addOption('lowercase', 'Lower case');
+        dropdown.addOption('uppercase', 'Upper case');
+
+        dropdown.setValue(this.plugin.settings.folderNameCase || 'default');
+
+        dropdown.onChange(async (value) => {
+          this.plugin.settings.folderNameCase = value;
+          await this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
       .setName('Episode subfolder')
       .setDesc('Folder inside the base folder where podcast episodes will be saved (leave empty to save directly in the base folder).')
       .addText(text => text

--- a/src/settings_modal.ts
+++ b/src/settings_modal.ts
@@ -256,6 +256,16 @@ export class SnipdSettingModal extends PluginSettingTab {
         }));
 
     new Setting(containerEl)
+      .setName('Sync README')
+      .setDesc('Sync the Snipd README file to the base folder.')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.syncReadme)
+        .onChange(async (value) => {
+          this.plugin.settings.syncReadme = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
       .setName('Sync frequency')
       .setDesc('Automatically sync at the specified interval')
       .addDropdown(dropdown => {

--- a/src/settings_modal.ts
+++ b/src/settings_modal.ts
@@ -220,6 +220,42 @@ export class SnipdSettingModal extends PluginSettingTab {
         }));
 
     new Setting(containerEl)
+      .setName('Episode subfolder')
+      .setDesc('Folder inside the base folder where podcast episodes will be saved (leave empty to save directly in the base folder).')
+      .addText(text => text
+        .setPlaceholder('Data')
+        .setValue(this.plugin.settings.subDir)
+        .onChange(async (value) => {
+          let val = value.trim();
+          if (val) {
+            val = normalizePath(val);
+            if (val === '.') {
+              val = '';
+            }
+          }
+          this.plugin.settings.subDir = val;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName('Index subfolder')
+      .setDesc('Folder inside the base folder where the Snipd base index file is saved (leave empty to save directly in the base folder).')
+      .addText(text => text
+        .setPlaceholder('Base')
+        .setValue(this.plugin.settings.baseSubDir)
+        .onChange(async (value) => {
+          let val = value.trim();
+          if (val) {
+            val = normalizePath(val);
+            if (val === '.') {
+              val = '';
+            }
+          }
+          this.plugin.settings.baseSubDir = val;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
       .setName('Sync frequency')
       .setDesc('Automatically sync at the specified interval')
       .addDropdown(dropdown => {

--- a/src/settings_modal.ts
+++ b/src/settings_modal.ts
@@ -256,6 +256,26 @@ export class SnipdSettingModal extends PluginSettingTab {
         }));
 
     new Setting(containerEl)
+      .setName('Index filename')
+      .setDesc('Filename of the Snipd base index file.')
+      .addText(text => text
+        .setPlaceholder('Snipd.base')
+        .setValue(this.plugin.settings.baseFileName)
+        .onChange(async (value) => {
+          let val = value.trim();
+          if (val) {
+            val = normalizePath(val);
+            if (val === '.') {
+              val = 'Snipd.base';
+            }
+          } else {
+            val = 'Snipd.base';
+          }
+          this.plugin.settings.baseFileName = val;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
       .setName('Sync README')
       .setDesc('Sync the Snipd README file to the base folder.')
       .addToggle(toggle => toggle

--- a/src/settings_modal.ts
+++ b/src/settings_modal.ts
@@ -240,6 +240,16 @@ export class SnipdSettingModal extends PluginSettingTab {
       });
 
     new Setting(containerEl)
+      .setName('Group episodes into folders')
+      .setDesc('Group episode notes into subfolders named after their podcast shows.')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.groupFilesIntoFolders)
+        .onChange(async (value) => {
+          this.plugin.settings.groupFilesIntoFolders = value;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
       .setName('Episode subfolder')
       .setDesc('Folder inside the base folder where podcast episodes will be saved (leave empty to save directly in the base folder).')
       .addText(text => text

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface SnipdPluginSettings {
   additionalProperties: Array<{ name: string; template: string; displayName?: string; }> | null;
   saveDebugZips: boolean;
   onlyEditedSnips: boolean;
+  subDir: string;
+  baseSubDir: string;
 }
 
 export const DEFAULT_EPISODE_TEMPLATE = `# {{episode_title}}
@@ -101,6 +103,8 @@ export const DEFAULT_SETTINGS: SnipdPluginSettings = {
   snipTemplate: null,
   episodeFileNameTemplate: null,
   additionalProperties: null,
+  subDir: "Data",
+  baseSubDir: "Base",
 };
 
 export interface MetadataJson {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface SnipdPluginSettings {
   subDir: string;
   baseSubDir: string;
   syncReadme: boolean;
+  baseFileName: string;
 }
 
 export const DEFAULT_EPISODE_TEMPLATE = `# {{episode_title}}
@@ -107,6 +108,7 @@ export const DEFAULT_SETTINGS: SnipdPluginSettings = {
   subDir: "Data",
   baseSubDir: "Base",
   syncReadme: true,
+  baseFileName: "Snipd.base",
 };
 
 export interface MetadataJson {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface SnipdPluginSettings {
   baseSubDir: string;
   syncReadme: boolean;
   baseFileName: string;
+  folderNameCase: string;
 }
 
 export const DEFAULT_EPISODE_TEMPLATE = `# {{episode_title}}
@@ -109,6 +110,7 @@ export const DEFAULT_SETTINGS: SnipdPluginSettings = {
   baseSubDir: "Base",
   syncReadme: true,
   baseFileName: "Snipd.base",
+  folderNameCase: "default",
 };
 
 export interface MetadataJson {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface SnipdPluginSettings {
   syncReadme: boolean;
   baseFileName: string;
   folderNameCase: string;
+  groupFilesIntoFolders: boolean;
 }
 
 export const DEFAULT_EPISODE_TEMPLATE = `# {{episode_title}}
@@ -111,6 +112,7 @@ export const DEFAULT_SETTINGS: SnipdPluginSettings = {
   syncReadme: true,
   baseFileName: "Snipd.base",
   folderNameCase: "default",
+  groupFilesIntoFolders: true,
 };
 
 export interface MetadataJson {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface SnipdPluginSettings {
   onlyEditedSnips: boolean;
   subDir: string;
   baseSubDir: string;
+  syncReadme: boolean;
 }
 
 export const DEFAULT_EPISODE_TEMPLATE = `# {{episode_title}}
@@ -105,6 +106,7 @@ export const DEFAULT_SETTINGS: SnipdPluginSettings = {
   additionalProperties: null,
   subDir: "Data",
   baseSubDir: "Base",
+  syncReadme: true,
 };
 
 export interface MetadataJson {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,8 +45,8 @@ export function toUpperCase(str: string): string {
   return str.toUpperCase();
 }
 
-function applyFilter(value: string, filterName: string): string {
-  switch (filterName) {
+export function applyCaseFormat(value: string, format: string): string {
+  switch (format) {
     case 'kebab':
       return toKebabCase(value);
     case 'snake':
@@ -86,7 +86,7 @@ export function generateEpisodeFileName(
   let result = template.replace(/\{\{([a-zA-Z0-9_]+)(?:\s*\|\s*([a-zA-Z0-9_]+))?\}\}\[\[.*?\]\]/g, (_, varName: string, filterName: string | undefined) => {
     let value = variables[varName] || '';
     if (value && filterName) {
-      value = applyFilter(value, filterName);
+      value = applyCaseFormat(value, filterName);
     }
     return value;
   });
@@ -97,7 +97,7 @@ export function generateEpisodeFileName(
       debugLog(`Snipd plugin: Unknown variable {{${varName}}} in episode filename template`);
     }
     if (value && filterName) {
-      value = applyFilter(value, filterName);
+      value = applyCaseFormat(value, filterName);
     }
     return value;
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,58 @@ export const debugLog = (...args: unknown[]): void => {
   }
 };
 
+export function toKebabCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function toSnakeCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+export function toCamelCase(str: string): string {
+  const words = str.split(/[^\p{L}\p{N}]+/gu).filter(Boolean);
+  if (words.length === 0) return '';
+  return words[0].toLowerCase() + words.slice(1).map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join('');
+}
+
+export function toPascalCase(str: string): string {
+  const words = str.split(/[^\p{L}\p{N}]+/gu).filter(Boolean);
+  return words.map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join('');
+}
+
+export function toLowerCase(str: string): string {
+  return str.toLowerCase();
+}
+
+export function toUpperCase(str: string): string {
+  return str.toUpperCase();
+}
+
+function applyFilter(value: string, filterName: string): string {
+  switch (filterName) {
+    case 'kebab':
+      return toKebabCase(value);
+    case 'snake':
+      return toSnakeCase(value);
+    case 'camel':
+      return toCamelCase(value);
+    case 'pascal':
+      return toPascalCase(value);
+    case 'lowercase':
+      return toLowerCase(value);
+    case 'uppercase':
+      return toUpperCase(value);
+    default:
+      return value;
+  }
+}
+
 export function generateEpisodeFileName(
   episodeData: EpisodeEntityData | undefined, 
   episodeId: string,
@@ -31,14 +83,21 @@ export function generateEpisodeFileName(
     'episode_url': episodeData.episode_url || '',
   };
 
-  let result = template.replace(/\{\{([a-zA-Z0-9_]+)\}\}\[\[.*?\]\]/g, (_, varName: string) => {
-    return variables[varName] || '';
+  let result = template.replace(/\{\{([a-zA-Z0-9_]+)(?:\s*\|\s*([a-zA-Z0-9_]+))?\}\}\[\[.*?\]\]/g, (_, varName: string, filterName: string | undefined) => {
+    let value = variables[varName] || '';
+    if (value && filterName) {
+      value = applyFilter(value, filterName);
+    }
+    return value;
   });
 
-  result = result.replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (_, varName: string) => {
-    const value = variables[varName] || '';
-    if (!variables[varName]) {
+  result = result.replace(/\{\{([a-zA-Z0-9_]+)(?:\s*\|\s*([a-zA-Z0-9_]+))?\}\}/g, (_, varName: string, filterName: string | undefined) => {
+    let value = variables[varName] || '';
+    if (!(varName in variables)) {
       debugLog(`Snipd plugin: Unknown variable {{${varName}}} in episode filename template`);
+    }
+    if (value && filterName) {
+      value = applyFilter(value, filterName);
     }
     return value;
   });

--- a/styles.css
+++ b/styles.css
@@ -297,3 +297,8 @@ If your plugin does not need CSS, delete this file.
   font-size: 12px;
   font-weight: 600;
 }
+
+.snipd-kebab-tip {
+  margin-top: 4px;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
This PR adds support for filename case-formatting filters in the Obsidian template configuration. 

Users can now apply various casing conventions directly inside their filename template tags using the standard pipe ( | ) syntax (e.g.  {{episode_title | kebab}}).

Case Filters:
- | kebab  ->  my-episode-title
- | snake  ->  my_episode_title
- | camel  ->  myEpisodeTitle
- | pascal  ->  MyEpisodeTitle
- | lowercase  ->  my episode title
- | uppercase  ->  MY EPISODE TITLE

Also dded a tip in the custom formatting modal explaining how to apply the filters.

Added a possibility to modify the 'Data' subfolder name as well as the 'Base' subfolder.

Added a possibility to choose casing (kebab, snake etc.) for the podcast subfolders.

Added a possibility to not group podcast snips into subfolders.